### PR TITLE
Fixes the issues mentioned in #8. Thanks for this cool kwin script! :-)

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -9,7 +9,8 @@ function add_desktop()
 // shifts a window to the left if it's more to the right than number
 function shift_righter_than(client, number)
 {
-	if (client.desktop > number) {
+	if (client.desktop > number)
+	{
 		print(`Shifting ${client.caption} to desktop ${client.desktop - 1}`);
 		client.desktop -= 1;
 	}
@@ -35,7 +36,8 @@ function remove_desktop_with(number)
 	// Once shifted remove desktop with the highest number
 	// This is less efficient than deleting directly,
 	// BUT the workspace names do not get messed up over time
-	workspace.clientList().forEach((client) => {
+	workspace.clientList().forEach((client) =>
+	{
 		shift_righter_than(client, number)
 	});
 
@@ -48,7 +50,8 @@ function is_empty_desktop(number)
 {
 	print(`is_empty_desktop(${number})`)
 	var cls = workspace.clientList();
-	for (var i = 0; i < cls.length; ++i) {
+	for (var i = 0; i < cls.length; ++i)
+	{
 		let client = cls[i];
 		// is client on desktop?
 		if (client.x11DesktopIds.indexOf(number) !== -1 // works also in wayland...
@@ -71,7 +74,8 @@ function desktop_changed_for(client)
 {
 	print(`desktop_changed_for() -> Client ${client.caption} just moved to desktop number ${client.desktop}`);
 
-	if (client.desktop >= workspace.desktops) {
+	if (client.desktop >= workspace.desktops)
+	{
 		add_desktop();
 	}
 }
@@ -81,18 +85,21 @@ function desktop_changed_for(client)
  */
 function on_client_added(client)
 {
-	if (client === null) {
+	if (client === null)
+	{
 		// just in case
 		return;
 	}
 
-	if (client.skipPager) {
+	if (client.skipPager)
+	{
 		//ignore hidden windows
 		return;
 	}
 
 	// add a new desktop for a client too right
-	if (client.desktop >= workspace.desktops) {
+	if (client.desktop >= workspace.desktops)
+	{
 		add_desktop();
 	}
 
@@ -117,9 +124,11 @@ function on_desktop_switch(old_desktop)
 	// might happen if other plugins interfere with workspace creation/deletion
 	let loop_counter = 0;
 	let loop_limit = workspace.desktops;
-	for (; desktop < workspace.desktops && loop_counter < loop_limit; desktop++) {
+	for (; desktop < workspace.desktops && loop_counter < loop_limit; desktop++)
+	{
 		loop_counter++;
-		if (is_empty_desktop(desktop) && remove_desktop_with(desktop)) {
+		if (is_empty_desktop(desktop) && remove_desktop_with(desktop))
+		{
 			// we removed a desktop so we need to reduce our counter also
 			desktop--;
 		}

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -1,12 +1,15 @@
 const MIN_DESKTOPS = 2;
 const LOOP_LIMIT = 100;
 
-function add_desktop() {
+function add_desktop()
+{
 	print("add_desktop()");
 	workspace.desktops++;
 }
 
-function shift_righter_than(client, number) {
+// shifts a window to the left if it's more to the right than number
+function shift_righter_than(client, number)
+{
 	if (client.desktop > number) {
 		print(`Shifting ${client.caption} to desktop ${client.desktop - 1}`);
 		client.desktop--;
@@ -18,7 +21,8 @@ function shift_righter_than(client, number) {
  * Returns true if desktop was deleted, false if wasn't
  * @returns true if removed
  */
-function remove_desktop_with(number) {
+function remove_desktop_with(number)
+{
 	print(`remove_desktop_with(${number})`);
 
 	// don't do anything if below minimum desktops
@@ -40,7 +44,9 @@ function remove_desktop_with(number) {
 	return true;
 }
 
-function is_empty_desktop(number) {
+// tells if desktop has no windows of its own
+function is_empty_desktop(number)
+{
 	print(`is_empty_desktop(${number})`)
 	var cls = workspace.clientList();
 	for (var i = 0; i < cls.length; ++i) {
@@ -62,7 +68,8 @@ function is_empty_desktop(number) {
  * Checks for new created or moved windows if they are occupying the last desktop
  * -> if yes, create new one to the right
  */
-function desktop_changed_for(client) {
+function desktop_changed_for(client)
+{
 	print(`desktop_changed_for() -> Client ${client.caption} just moved to desktop number ${client.desktop}`);
 
 	if (client.desktop >= workspace.desktops) {
@@ -73,7 +80,8 @@ function desktop_changed_for(client) {
 /**
  * When creating new windows, check whether they are occupying the last desktop
  */
-function on_client_added(client) {
+function on_client_added(client)
+{
 	if (client === null) {
 		// just in case
 		return;
@@ -90,15 +98,14 @@ function on_client_added(client) {
 	}
 
 	// subscribe the client to create desktops when desktop switched
-	client.desktopChanged.connect(() => {
-		desktop_changed_for(client);
-	});
+	client.desktopChanged.connect(() => { desktop_changed_for(client); });
 }
 
 /**
  * Deletes empty desktops to the right in case of a left switch
  */
-function on_desktop_switch(old_desktop) {
+function on_desktop_switch(old_desktop)
+{
 	print(`on_desktop_switch(${old_desktop})`);
 
 	// do nothing if we switched to the right
@@ -119,14 +126,14 @@ function on_desktop_switch(old_desktop) {
 	}
 }
 
+
+/*****  Main part *****/
+
 // actions relating to creating desktops
 // also this subscribes all clients to their desktopChanged event
 workspace.clientAdded.connect(on_client_added);
-
 // also do this for all existing clients
 workspace.clientList().forEach(on_client_added);
 
 // handle change desktop events
-workspace.currentDesktopChanged.connect((old_desktop) => {
-	on_desktop_switch(old_desktop);
-});
+workspace.currentDesktopChanged.connect((old_desktop) => { on_desktop_switch(old_desktop); });

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -1,5 +1,4 @@
 const MIN_DESKTOPS = 2;
-const LOOP_LIMIT = 100;
 
 function add_desktop()
 {
@@ -116,9 +115,10 @@ function on_desktop_switch(old_desktop)
 
 	// prevent infinit loop in case of an error
 	// might happen if other plugins interfere with workspace creation/deletion
-	let safety = 0;
-	for (; desktop < workspace.desktops && safety < LOOP_LIMIT; desktop++) {
-		safety++;
+	let loop_counter = 0;
+	let loop_limit = workspace.desktops;
+	for (; desktop < workspace.desktops && loop_counter < loop_limit; desktop++) {
+		loop_counter++;
 		if (is_empty_desktop(desktop) && remove_desktop_with(desktop)) {
 			// we removed a desktop so we need to reduce our counter also
 			desktop--;

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -1,155 +1,159 @@
-function add_desktop()
-{
-	workspace.desktops += 1;
-}
+// capsule functionality from outer world
+const dynamicWorkspaceManager = (function () {
 
-// shifts a window to the left if it's more to the right than number
-function shift_righter_than(number)
-{
-	return function(client)
-	{
+	const MIN_DESKTOPS = 2;
+	const LOOP_LIMIT = 100;
+
+	function add_desktop() {
+		print("add_desktop()");
+		workspace.desktops++;
+	}
+	
+	function shift_righter_than(client, number) {
 		if (client.desktop > number) {
-			client.desktop -= 1;
+			print(`Shifting ${client.caption} to desktop ${client.desktop - 1}`);
+			client.desktop--;
 		}
 	}
-}
 
-// deletes last desktop without fanfare
-function delete_last()
-{
-	// don't do anything if last two remain
-	if (workspace.desktops <= 2)  return;
-	workspace.desktops -= 1;
-}
+	/**
+	 * Delete a desktop by number
+	 * Returns true if desktop was deleted, false if wasn't
+	 * @param {*} number 
+	 * @returns 
+	 */
+	function remove_desktop_with(number) {
+		print(`remove_desktop_with(${number})`);
 
-// simulates deletion of desktop in the middle
-// Returns true if desktop was deleted, false if wasn't
-function delete_desktop(number)
-{
-	print("delete desktop " + number);
-	// don't do anything for last desktop
-	if (workspace.desktops == 1)  return false;
-	if (workspace.desktops == number)  return false;
+		// don't do anything if below minimum desktops
+		if (workspace.desktops <= MIN_DESKTOPS) return false;
 
-	if (workspace.desktops == 2) {
-		// don't delete, only shift left
-		workspace.clientList().forEach(shift_righter_than(number));
-		return false;
-	}
+		// do not remove empty desktop at the end
+		if (workspace.desktops == number) return false;
 
-	if (number >= workspace.desktops - 1) {
-		// delete without shifting
-		delete_last();
+		// Shift all clients right from desktop $number to the left
+		// instead of deleting the desktop directly 
+		// Once shifted remove desktop with the highest number
+		// This is less efficient than deleting directly,  
+		// BUT the workspace names do not get messed up over time
+		workspace.clientList().forEach((client) => {
+			shift_righter_than(client, number)
+		});
+
+		workspace.removeDesktop(workspace.desktops - 1);
 		return true;
 	}
 
-	delete_last();
-	workspace.clientList().forEach(shift_righter_than(number));
-	return true;
-}
-
-// tells if desktop has no windows of its own
-function is_empty_desktop(number)
-{
-	var cls = workspace.clientList();
-	for (var i = 0; i < cls.length; ++i) {
-		if (cls[i].desktop == number
-			&& !cls[i].skipPager // don't count hidden windows
-		) {
-			print("Not empty: " + cls[i].caption + " is there");
-			return false;
+	/**
+	 * tells if desktop has no windows of its own
+	 * @param {*} number 
+	 * @returns 
+	 */
+	function is_empty_desktop(number) {
+		print(`is_empty_desktop(${number})`)
+		var cls = workspace.clientList();
+		for (var i = 0; i < cls.length; ++i) {
+			let client = cls[i];
+			// is client on desktop?
+			if (client.x11DesktopIds.indexOf(number) !== -1 // works also in wayland...
+				&& !client.skipPager // ignore hidden windows
+				&& !client.onAllDesktops // ignore windows on all desktops
+			) {
+				print(`Desktop ${number} not empty because ${client.caption} is there`);
+				return false;
+			}
 		}
+
+		return true;
 	}
-	return true;
-}
 
-function is_last_empty()
-{
-	// -1 as we always have the last desktop that we keep empty for moving
-	// things to it
-	return is_empty_desktop(workspace.desktops - 1);
-}
-
-function delete_empty_last()
-{
-	if (is_last_empty()) {
-		delete_last();
-		print("deleted last desktop");
-	}
-}
-
-function desktop_changed_for(client)
-{
-	return function() {
-		var message = "Client " + client.caption + " just moved";
-		message += "\n to desktop number " + client.desktop;
-		message += " out of " + workspace.desktops;
+	/**
+	 * Checks for new created or moved windows if they are occupying the last desktop
+	 * -> if yes, create new one to the right
+	 * @param {*} client 
+	 * @returns 
+	 */
+	function desktop_changed_for(client) {
+		print(`desktop_changed_for() -> Client ${client.caption} just moved to desktop number ${client.desktop}`);
 
 		if (client.desktop >= workspace.desktops) {
 			add_desktop();
-			message += "\nadded a desktop";
 		}
-		else {
-			delete_empty_last();
+	}
+
+	/**
+	 * When creating new windows, check whether they are occupying the last desktop
+	 * @param {*} client 
+	 * @returns 
+	 */
+	function on_client_added(client) {
+		if (client === null) {
+			// just in case
+			return;
 		}
 
-		print(message);
-	}
-}
-
-
-function on_client_added(client)
-{
-	if (client === null) {
-		// just in case
-		return;
-	}
-
-	if (client.skipPager) {
-		//ignore hidden windows
-		return;
-	}
-
-	// add a new desktop for a client too right
-	if (client.desktop >= workspace.desktops) {
-		add_desktop();
-	}
-
-	// subscribe the client to create desktops when desktop switched
-	client.desktopChanged.connect(desktop_changed_for(client))
-}
-
-function on_desktop_changed(old_desktop, client)
-{
-	// delete empty desktops that we swithced from
-
-	if (old_desktop !== workspace.desktops && is_empty_desktop(old_desktop)) {
-		// delete desktop
-		// only delete desktop if doing so would be unnoticeable
-		if (old_desktop > workspace.currentDesktop) {
-			delete_desktop(old_desktop);
+		if (client.skipPager) {
+			//ignore hidden windows
+			return;
 		}
-	} else if (workspace.currentDesktop === 1) {
-		// delete all empty desktops to the right if we switched to first
-		for (var i = 1; i < workspace.desktops; ++i) {
-			if (is_empty_desktop(i)) {
-				var deleted = delete_desktop(i);
-				if (deleted) {
-					i -= 1;
-				}
+
+		// add a new desktop for a client too right
+		if (client.desktop >= workspace.desktops) {
+			add_desktop();
+		}
+
+		// subscribe the client to create desktops when desktop switched
+		client.desktopChanged.connect(() => {
+			desktop_changed_for(client);
+		});
+	}
+
+	/**
+	 * Deletes empty desktops to the right in case of a left switch
+	 * @param {*} old_desktop 
+	 */
+	function on_desktop_switch(old_desktop) {
+		print(`on_desktop_switch(${old_desktop})`);
+
+		// do nothing if we switched to the right
+		if (old_desktop <= workspace.currentDesktop) return;
+
+		// start from next desktop to the right
+		let desktop = workspace.currentDesktop + 1;
+
+		// prevent infinit loop in case of an error
+		// might happen if other plugins interfere with workspace creation/deletion
+		let safety = 0;
+		for (; desktop < workspace.desktops && safety < LOOP_LIMIT; desktop++) {
+			safety++;
+			if (is_empty_desktop(desktop) && remove_desktop_with(desktop)) {
+				// we removed a desktop so we need to reduce our counter also
+				desktop--;
 			}
 		}
 	}
-}
+
+	function init() {
+		print("init()");
+
+		// actions relating to creating desktops
+		// also this subscribes all clients to their desktopChanged event
+		workspace.clientAdded.connect(on_client_added);
+
+		// also do this for all existing clients
+		workspace.clientList().forEach(on_client_added);
+
+		// handle change desktop events
+		workspace.currentDesktopChanged.connect((old_desktop) => {
+			on_desktop_switch(old_desktop);
+		});
+	}
+
+	return {
+		init: init
+	}
+})();
 
 
-/*****  Main part *****/
+dynamicWorkspaceManager.init();
 
-// actions relating to creating desktops
-// also this subscribes all clients to their desktopChanged event
-workspace.clientAdded.connect(on_client_added);
-// also do this for all existing clients
-workspace.clientList().forEach(on_client_added);
-
-// actions relating to deleting desktops
-workspace.currentDesktopChanged.connect(on_desktop_changed);

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -3,7 +3,7 @@ const MIN_DESKTOPS = 2;
 function add_desktop()
 {
 	print("add_desktop()");
-	workspace.desktops++;
+	workspace.desktops += 1;
 }
 
 // shifts a window to the left if it's more to the right than number
@@ -11,7 +11,7 @@ function shift_righter_than(client, number)
 {
 	if (client.desktop > number) {
 		print(`Shifting ${client.caption} to desktop ${client.desktop - 1}`);
-		client.desktop--;
+		client.desktop -= 1;
 	}
 }
 

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -1,159 +1,132 @@
-// capsule functionality from outer world
-const dynamicWorkspaceManager = (function () {
+const MIN_DESKTOPS = 2;
+const LOOP_LIMIT = 100;
 
-	const MIN_DESKTOPS = 2;
-	const LOOP_LIMIT = 100;
+function add_desktop() {
+	print("add_desktop()");
+	workspace.desktops++;
+}
 
-	function add_desktop() {
-		print("add_desktop()");
-		workspace.desktops++;
+function shift_righter_than(client, number) {
+	if (client.desktop > number) {
+		print(`Shifting ${client.caption} to desktop ${client.desktop - 1}`);
+		client.desktop--;
 	}
-	
-	function shift_righter_than(client, number) {
-		if (client.desktop > number) {
-			print(`Shifting ${client.caption} to desktop ${client.desktop - 1}`);
-			client.desktop--;
+}
+
+/**
+ * Delete a desktop by number
+ * Returns true if desktop was deleted, false if wasn't
+ * @returns true if removed
+ */
+function remove_desktop_with(number) {
+	print(`remove_desktop_with(${number})`);
+
+	// don't do anything if below minimum desktops
+	if (workspace.desktops <= MIN_DESKTOPS) return false;
+
+	// do not remove empty desktop at the end
+	if (workspace.desktops == number) return false;
+
+	// Shift all clients right from desktop $number to the left
+	// instead of deleting the desktop directly
+	// Once shifted remove desktop with the highest number
+	// This is less efficient than deleting directly,
+	// BUT the workspace names do not get messed up over time
+	workspace.clientList().forEach((client) => {
+		shift_righter_than(client, number)
+	});
+
+	workspace.removeDesktop(workspace.desktops - 1);
+	return true;
+}
+
+function is_empty_desktop(number) {
+	print(`is_empty_desktop(${number})`)
+	var cls = workspace.clientList();
+	for (var i = 0; i < cls.length; ++i) {
+		let client = cls[i];
+		// is client on desktop?
+		if (client.x11DesktopIds.indexOf(number) !== -1 // works also in wayland...
+			&& !client.skipPager // ignore hidden windows
+			&& !client.onAllDesktops // ignore windows on all desktops
+		) {
+			print(`Desktop ${number} not empty because ${client.caption} is there`);
+			return false;
 		}
 	}
 
-	/**
-	 * Delete a desktop by number
-	 * Returns true if desktop was deleted, false if wasn't
-	 * @param {*} number 
-	 * @returns 
-	 */
-	function remove_desktop_with(number) {
-		print(`remove_desktop_with(${number})`);
+	return true;
+}
 
-		// don't do anything if below minimum desktops
-		if (workspace.desktops <= MIN_DESKTOPS) return false;
+/**
+ * Checks for new created or moved windows if they are occupying the last desktop
+ * -> if yes, create new one to the right
+ */
+function desktop_changed_for(client) {
+	print(`desktop_changed_for() -> Client ${client.caption} just moved to desktop number ${client.desktop}`);
 
-		// do not remove empty desktop at the end
-		if (workspace.desktops == number) return false;
+	if (client.desktop >= workspace.desktops) {
+		add_desktop();
+	}
+}
 
-		// Shift all clients right from desktop $number to the left
-		// instead of deleting the desktop directly 
-		// Once shifted remove desktop with the highest number
-		// This is less efficient than deleting directly,  
-		// BUT the workspace names do not get messed up over time
-		workspace.clientList().forEach((client) => {
-			shift_righter_than(client, number)
-		});
-
-		workspace.removeDesktop(workspace.desktops - 1);
-		return true;
+/**
+ * When creating new windows, check whether they are occupying the last desktop
+ */
+function on_client_added(client) {
+	if (client === null) {
+		// just in case
+		return;
 	}
 
-	/**
-	 * tells if desktop has no windows of its own
-	 * @param {*} number 
-	 * @returns 
-	 */
-	function is_empty_desktop(number) {
-		print(`is_empty_desktop(${number})`)
-		var cls = workspace.clientList();
-		for (var i = 0; i < cls.length; ++i) {
-			let client = cls[i];
-			// is client on desktop?
-			if (client.x11DesktopIds.indexOf(number) !== -1 // works also in wayland...
-				&& !client.skipPager // ignore hidden windows
-				&& !client.onAllDesktops // ignore windows on all desktops
-			) {
-				print(`Desktop ${number} not empty because ${client.caption} is there`);
-				return false;
-			}
-		}
-
-		return true;
+	if (client.skipPager) {
+		//ignore hidden windows
+		return;
 	}
 
-	/**
-	 * Checks for new created or moved windows if they are occupying the last desktop
-	 * -> if yes, create new one to the right
-	 * @param {*} client 
-	 * @returns 
-	 */
-	function desktop_changed_for(client) {
-		print(`desktop_changed_for() -> Client ${client.caption} just moved to desktop number ${client.desktop}`);
+	// add a new desktop for a client too right
+	if (client.desktop >= workspace.desktops) {
+		add_desktop();
+	}
 
-		if (client.desktop >= workspace.desktops) {
-			add_desktop();
+	// subscribe the client to create desktops when desktop switched
+	client.desktopChanged.connect(() => {
+		desktop_changed_for(client);
+	});
+}
+
+/**
+ * Deletes empty desktops to the right in case of a left switch
+ */
+function on_desktop_switch(old_desktop) {
+	print(`on_desktop_switch(${old_desktop})`);
+
+	// do nothing if we switched to the right
+	if (old_desktop <= workspace.currentDesktop) return;
+
+	// start from next desktop to the right
+	let desktop = workspace.currentDesktop + 1;
+
+	// prevent infinit loop in case of an error
+	// might happen if other plugins interfere with workspace creation/deletion
+	let safety = 0;
+	for (; desktop < workspace.desktops && safety < LOOP_LIMIT; desktop++) {
+		safety++;
+		if (is_empty_desktop(desktop) && remove_desktop_with(desktop)) {
+			// we removed a desktop so we need to reduce our counter also
+			desktop--;
 		}
 	}
+}
 
-	/**
-	 * When creating new windows, check whether they are occupying the last desktop
-	 * @param {*} client 
-	 * @returns 
-	 */
-	function on_client_added(client) {
-		if (client === null) {
-			// just in case
-			return;
-		}
+// actions relating to creating desktops
+// also this subscribes all clients to their desktopChanged event
+workspace.clientAdded.connect(on_client_added);
 
-		if (client.skipPager) {
-			//ignore hidden windows
-			return;
-		}
+// also do this for all existing clients
+workspace.clientList().forEach(on_client_added);
 
-		// add a new desktop for a client too right
-		if (client.desktop >= workspace.desktops) {
-			add_desktop();
-		}
-
-		// subscribe the client to create desktops when desktop switched
-		client.desktopChanged.connect(() => {
-			desktop_changed_for(client);
-		});
-	}
-
-	/**
-	 * Deletes empty desktops to the right in case of a left switch
-	 * @param {*} old_desktop 
-	 */
-	function on_desktop_switch(old_desktop) {
-		print(`on_desktop_switch(${old_desktop})`);
-
-		// do nothing if we switched to the right
-		if (old_desktop <= workspace.currentDesktop) return;
-
-		// start from next desktop to the right
-		let desktop = workspace.currentDesktop + 1;
-
-		// prevent infinit loop in case of an error
-		// might happen if other plugins interfere with workspace creation/deletion
-		let safety = 0;
-		for (; desktop < workspace.desktops && safety < LOOP_LIMIT; desktop++) {
-			safety++;
-			if (is_empty_desktop(desktop) && remove_desktop_with(desktop)) {
-				// we removed a desktop so we need to reduce our counter also
-				desktop--;
-			}
-		}
-	}
-
-	function init() {
-		print("init()");
-
-		// actions relating to creating desktops
-		// also this subscribes all clients to their desktopChanged event
-		workspace.clientAdded.connect(on_client_added);
-
-		// also do this for all existing clients
-		workspace.clientList().forEach(on_client_added);
-
-		// handle change desktop events
-		workspace.currentDesktopChanged.connect((old_desktop) => {
-			on_desktop_switch(old_desktop);
-		});
-	}
-
-	return {
-		init: init
-	}
-})();
-
-
-dynamicWorkspaceManager.init();
-
+// handle change desktop events
+workspace.currentDesktopChanged.connect((old_desktop) => {
+	on_desktop_switch(old_desktop);
+});


### PR DESCRIPTION
Fixed bug when closing multiple empty workspaces at once, windows from different workspaces get mixed together in one instead of being seperate. Fixed not closing all empty workspaces to the right when using plasma workspace switcher on task bar.

Refactored code and encapsulated functionality. Added syntactic sugar for better readability. Added safety in case of an error if another plugin is also interfering with workspaces